### PR TITLE
[fix] fix to simulate cmi

### DIFF
--- a/smsc.go
+++ b/smsc.go
@@ -226,8 +226,15 @@ func handleSmppConnection(smsc *Smsc, conn net.Conn) {
 				registeredDlr := pduBody[idxCounter+1] // registered_delivery is next field after the validity_period
 
 				// prepare submit_sm_resp
-				msgId := strconv.Itoa(rand.Int())
-				respBytes = stringBodyPDU(SUBMIT_SM_RESP, STS_OK, seqNum, msgId)
+				// msgId := strconv.Itoa(rand.Int())
+				// respBytes = stringBodyPDU(SUBMIT_SM_RESP, STS_OK, seqNum, msgId)
+
+				// deal with message id to simulate cmi
+				// msgId need format to hex in submit_sm
+				id := rand.Int()
+				msgId := strconv.Itoa(id)
+				msgIdHex := strconv.FormatInt(int64(id), 16)
+				respBytes = stringBodyPDU(SUBMIT_SM_RESP, STS_OK, seqNum, msgIdHex)
 
 				if registeredDlr != 0 {
 					go func() {


### PR DESCRIPTION
修改为与 cmi 的处理一样：
对于 messageId，delivery_sm 的 data 中直接返回原数据， submit_sm_resp 中返回的是转为 16 进制后的数据
